### PR TITLE
make logDir and logUser customizable

### DIFF
--- a/src/main/groovy/nebula/plugin/ospackage/daemon/DaemonDefinition.groovy
+++ b/src/main/groovy/nebula/plugin/ospackage/daemon/DaemonDefinition.groovy
@@ -16,5 +16,6 @@ class DaemonDefinition {
     Boolean autoStart // default true
     Integer startSequence // default 85
     Integer stopSequence // default 15
-
+    String logDir // defaults to "./main"
+    String logUser // defaults to "nobody"
 }

--- a/src/main/groovy/nebula/plugin/ospackage/daemon/OspackageDaemonPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/ospackage/daemon/OspackageDaemonPlugin.groovy
@@ -33,6 +33,8 @@ class OspackageDaemonPlugin implements Plugin<Project> {
                 command: definition.command,
                 user: definition.user ?: definitionDefaults.user,
                 logCommand: definition.logCommand ?: definitionDefaults.logCommand,
+                logUser: definition.logUser ?: definitionDefaults.logUser,
+                logDir: definition.logDir ?: definitionDefaults.logDir,
                 runLevels: definition.runLevels ?: definitionDefaults.runLevels,
                 autoStart: definition.autoStart != null? definition.autoStart : definitionDefaults.autoStart,
                 startSequence: definition.startSequence ?: definitionDefaults.startSequence,

--- a/src/main/resources/nebula/plugin/ospackage/daemon/log-run.tpl
+++ b/src/main/resources/nebula/plugin/ospackage/daemon/log-run.tpl
@@ -1,4 +1,4 @@
 #!/bin/sh
-mkdir -p ./main
-chown nobody:nobody ./main
-exec setuidgid nobody ${logCommand}
+mkdir -p ${logDir}
+chown ${logUser}:nobody ${logDir}
+exec setuidgid ${logUser} ${logCommand}

--- a/src/test/groovy/nebula/plugin/ospackage/daemon/DaemonExtensionSpec.groovy
+++ b/src/test/groovy/nebula/plugin/ospackage/daemon/DaemonExtensionSpec.groovy
@@ -13,6 +13,8 @@ class DaemonExtensionSpec extends Specification {
             daemonName = 'foobar'
             command = 'exit 0'
             user = 'builds'
+            logUser = 'root'
+            logDir = '/tmp'
             logCommand = 'multipass'
             runLevels = [1,2]
             autoStart = false
@@ -26,6 +28,8 @@ class DaemonExtensionSpec extends Specification {
         definition.daemonName == 'foobar'
         definition.command == 'exit 0'
         definition.user == 'builds'
+        definition.logUser == 'root'
+        definition.logDir == '/tmp'
         definition.logCommand == 'multipass'
         definition.runLevels == [1,2]
         !definition.autoStart

--- a/src/test/groovy/nebula/plugin/ospackage/daemon/OspackageDaemonPluginLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/ospackage/daemon/OspackageDaemonPluginLauncherSpec.groovy
@@ -67,6 +67,8 @@ class OspackageDaemonPluginLauncherSpec extends IntegrationSpec {
                   daemonName = "fooqux" // default = packageName
                   command = "sleep infinity" // required
                   user = "nobody" // default = "root"
+                  logUser = "root" // default = "nobody"
+                  logDir = "/tmp" // default = "./main"
                   logCommand = "cronolog /logs/foobar/foobar.log" // default = "multilog t ./main"
                   runLevels = [3,4] // rpm default == [3,4,5], deb default = [2,3,4,5]
                   autoStart = false // default = true


### PR DESCRIPTION
we need to be able to mkdir on logDir and change the user that the logger runs as by default.

Ideally we would change the default logCommand to "multilog t ${logDir}" but I could not figure out how to set the default logCommand that may or may not use a default logDir.  So with this patch if if someone wants a custom logDir they will usually need to create a custom logCommand also.

-Cory
